### PR TITLE
Resolve server ip from dns, Use InterNetworkV6 address family for soc…

### DIFF
--- a/Client.cs
+++ b/Client.cs
@@ -87,7 +87,7 @@ namespace rmnp
 		// Client.ServerTimeout is called.
 		public void Connect(byte[] data)
 		{
-			this.SetSocket(new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp));
+			this.SetSocket(new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp));
 			this.Listen();
 			this.Server = this.ConnectClient(this.Address, data);
 		}

--- a/RMNP.cs
+++ b/RMNP.cs
@@ -52,7 +52,8 @@ namespace rmnp
 			if (!address.Contains(":")) throw new Exception("Port has to be specified");
 
 			string[] data = address.Split(':');
-			this.Address = new IPEndPoint(IPAddress.Parse(data[0]), int.Parse(data[1]));
+			var dnsAddress = Dns.GetHostAddresses(data[0])[0];
+			this.Address = new IPEndPoint(dnsAddress, int.Parse(data[1]));
 
 			this.listeners = new List<Thread>();
 			this.connectGuard = new ExecGuard();

--- a/Server.cs
+++ b/Server.cs
@@ -85,7 +85,7 @@ namespace rmnp
 		// the server is guaranteed to be running after this call.
 		public void Start()
 		{
-			Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+			Socket socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
 			socket.Bind(this.Address);
 			this.Listen();
 		}


### PR DESCRIPTION
…kets to support ipv6

I wouldn't call this a full solution as it appears you could use only ipv4 addresses before and with these changes you can use hostnames like localhost or domain names. It the changes do result in 127.0.0.1 failing to connect however even when enabling DualMode on the socket.