### PR TITLE
Remove keep alive check that would always return true when disconnected

### DIFF
--- a/Connection.cs
+++ b/Connection.cs
@@ -204,12 +204,7 @@ namespace rmnp
 		private void KeepAlive()
 		{
 			// case < -time.After((CfgTimeoutThreshold / 2) * time.Millisecond):
-
-			if (this.GetState() == ConnectionState.DISCONNECTED)
-			{
-				return;
-			}
-
+			
 			long currentTime = Util.CurrentTime();
 
 			if (currentTime - this.lastReceivedTime > Config.CfgTimeoutThreshold || this.GetPing() > Config.CfgMaxPing)


### PR DESCRIPTION
In a side note, the timeout handlers really shouldn't ever return any sort of data. Im not sure the handlers need to keep the data parameter as a result.