### PR TITLE
Fix memory leak due to non blocking sockets

### DIFF
--- a/RMNP.cs
+++ b/RMNP.cs
@@ -99,7 +99,7 @@ namespace rmnp
 			this.Socket = socket;
 			this.Socket.SendBufferSize = Config.CfgMTU;
 			this.Socket.ReceiveBufferSize = Config.CfgMTU;
-			this.Socket.Blocking = false;
+			this.Socket.ReceiveTimeout = 1000;
 		}
 
 		protected void Listen()
@@ -129,7 +129,6 @@ namespace rmnp
 
 					byte[] buffer = this.bufferPool.Get();
 
-					this.Socket.ReceiveTimeout = 1000;
 					this.readFunc(this.Socket, ref buffer, out length, out addr, out next);
 
 					if (!next)


### PR DESCRIPTION
The issue was caused by an exception in the receive call throwing an exception. "Operation on non-blocking socket would block"

https://github.com/obsilp/rmnp-csharp/blob/master/Client.cs#L36-L42

The exception was being caught quietly and firing constantly which seemingly didn't affect newer .net versions but would result in thousands of allocations in Unity.